### PR TITLE
Use Kaminari's default config for (max_)per_page

### DIFF
--- a/lib/grape/kaminari.rb
+++ b/lib/grape/kaminari.rb
@@ -21,8 +21,8 @@ module Grape
 
         def self.paginate(options = {})
           options.reverse_merge!(
-            per_page: 10,
-            max_per_page: false
+            per_page: ::Kaminari.config.default_per_page || 10,
+            max_per_page: ::Kaminari.config.max_per_page
           )
           params do
             optional :page,     type: Integer, default: 1,


### PR DESCRIPTION
Use Kaminari's config which is generated from running `rails g kaminari:config`.

You will still need to call `paginate` outside the `get`. I was looking for a way to do this automatically but couldn't think of an easy/quick implementation.
