### PR TITLE
Add kaminari-grape dependency

### DIFF
--- a/grape-kaminari.gemspec
+++ b/grape-kaminari.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "grape"
   spec.add_runtime_dependency "kaminari"
-  spec.add_runtime_dependency "kaminari-grape"
+  spec.add_runtime_dependency "kaminari-grape", "1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/grape-kaminari.gemspec
+++ b/grape-kaminari.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "grape"
   spec.add_runtime_dependency "kaminari"
+  spec.add_runtime_dependency "kaminari-grape"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This corrects the following error when attempting to load the `grape-kaminari` gem. `kaminari-grape` now appears to be a needed dependency.

```
LoadError: cannot load such file -- kaminari/grape
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `block in require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:240:in `load_dependency'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/grape-kaminari-0.1.9/lib/grape/kaminari.rb:4:in `<top (required)>'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `block in require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:240:in `load_dependency'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/grape-kaminari-0.1.9/lib/grape-kaminari.rb:11:in `<top (required)>'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `block in require'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:240:in `load_dependency'
  /Users/jaronson/.rbenv/versions/2.3.3/gemsets/beachy-api/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
```