### PR TITLE
compatibility/grape 1.6.1+ dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grape-kaminari (0.4.1)
+    grape-kaminari (0.4.2)
       grape (>= 1.6.1, != 1.4.0)
       kaminari-grape
 
@@ -127,4 +127,4 @@ DEPENDENCIES
   rubocop-bsm
 
 BUNDLED WITH
-   2.2.32
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     grape-kaminari (0.4.1)
-      grape (>= 1.0, != 1.4.0)
+      grape (>= 1.6.1, != 1.4.0)
       kaminari-grape
 
 GEM
@@ -36,7 +36,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    grape (1.5.3)
+    grape (1.6.2)
       activesupport
       builder
       dry-types (>= 1.1)
@@ -127,4 +127,4 @@ DEPENDENCIES
   rubocop-bsm
 
 BUNDLED WITH
-   2.1.4
+   2.2.32

--- a/grape-kaminari.gemspec
+++ b/grape-kaminari.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5'
 
-  spec.add_runtime_dependency 'grape', '>= 1.0', '!= 1.4.0'
+  spec.add_runtime_dependency 'grape', '>= 1.6.1', '!= 1.4.0'
   spec.add_runtime_dependency 'kaminari-grape'
 
   spec.add_development_dependency 'bundler'

--- a/lib/grape/kaminari/max_value_validator.rb
+++ b/lib/grape/kaminari/max_value_validator.rb
@@ -1,6 +1,6 @@
 module Grape
   module Kaminari
-    class MaxValueValidator < Grape::Validations::Base
+    class MaxValueValidator < Grape::Validations::Validators::Base
       def validate_param!(attr_name, params)
         attr = params[attr_name]
         return unless attr.is_a?(Integer) && @option && attr > @option

--- a/lib/grape/kaminari/version.rb
+++ b/lib/grape/kaminari/version.rb
@@ -1,5 +1,5 @@
 module Grape
   module Kaminari
-    VERSION = '0.4.1'.freeze
+    VERSION = '0.4.2'.freeze
   end
 end


### PR DESCRIPTION
This PR solves #61 

The main issue was a new module included. The fix consists of the update of this new module on `Grape::Kaminari::MaxValueValidator` class.